### PR TITLE
Added Travis job to run 'python3.6 setup.py test' instead of tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
           env: TOXENV=py27
         - python: 3.6
           env: TOXENV=py36
+        - python: 3.6
+          script:
+              - python3.6 setup.py test
 
 install:
     - travis_retry pip install tox


### PR DESCRIPTION
This adds a third build to the Travis matrix, to run `python3.6 setup.py test` instead of tox.  
This will catch installation issues of the type seen in #403.