### PR TITLE
Added version header as X-Powered-By: httpbin/<version>

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -14,6 +14,7 @@ import random
 import time
 import uuid
 import argparse
+import pkg_resources
 
 from flask import Flask, Response, request, render_template, redirect, jsonify as flask_jsonify, make_response, url_for, abort
 from six.moves import range as xrange
@@ -108,6 +109,8 @@ def before_request():
 def set_cors_headers(response):
     response.headers['Access-Control-Allow-Origin'] = request.headers.get('Origin', '*')
     response.headers['Access-Control-Allow-Credentials'] = 'true'
+    version = pkg_resources.require("httpbin")[0].version
+    response.headers['X-Powered-By'] = 'httpbin/' + version
 
     if request.method == 'OPTIONS':
         # Both of these headers are only used for the "preflight request"


### PR DESCRIPTION
This PR adds a HTTP response header `X-Powered-By` containing `httpbin` and its version:

```
Server: gunicorn/19.8.1
X-Powered-By: httpbin/0.6.2
```

This might have been done using multiple products in the `Server` header, but I suspect that a lot of upstream reverse-proxies etc., perhaps `nginx`, `gunicorn` will just overwrite what is written there.

Fixed #431.