### PR TITLE
Adjusts in layout + categorized endpoints

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -56,6 +56,8 @@ tmpl_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
 app = Flask(__name__, template_folder=tmpl_dir)
 app.debug = bool(os.environ.get('DEBUG'))
 
+app.add_template_global('HTTPBIN_TRACKING' in os.environ, name='tracking_enabled')
+
 app.config['SWAGGER'] = {
     'title': 'httpbin.org',
     'uiversion': 3

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -67,7 +67,10 @@ template = {
   "swagger": "2.0",
   "info": {
     "title": "httpbin.org",
-    "description": "A simple HTTP Service. <br/> <br/> <code>$ docker run -p 80:80 kennethreitz/httpbin</code>",
+    "description": (
+        "A simple HTTP Request & Response Service."
+        "<br/> <br/> <b>Run locally: </b> <code>$ docker run -p 80:80 kennethreitz/httpbin</code>"
+    ),
     "contact": {
       "responsibleOrganization": "Kenneth Reitz",
       "responsibleDeveloper": "Kenneth Reitz",

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -1472,6 +1472,35 @@ def xml():
     return response
 
 
+@app.route("/json")
+def a_json_endpoint():
+    """Returns a simple JSON document.
+    ---
+    tags:
+      - Response formats
+    responses:
+      200:
+        description: An JSON document.
+    """
+    return flask_jsonify(
+        slideshow={
+            'title': 'Sample Slide Show',
+            'date': 'date of publication',
+            'author': 'Yours Truly',
+            'slides': [
+                {'type': 'all',
+                 'title': 'Wake up to WonderWidgets!'},
+                {'type': 'all',
+                 'title': 'Overview',
+                 'items': [
+                    'Why <em>WonderWidgets</em> are great',
+                    'Who <em>buys</em> WonderWidgets'
+                 ]}
+            ]
+        }
+    )
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=5000)

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -80,11 +80,29 @@ template = {
     # "termsOfService": "http://me.com/terms",
     "version": "0.9.0"
   },
-  "host": "httpbin.org",  # overrides localhost:500
+  "host": "httpbin.org",  # overrides localhost:5000
   "basePath": "/",  # base bash for blueprint registration
   "schemes": [
-    "http",
-    "https"
+    "https",
+    "http"
+  ],
+  'protocol': 'https',
+  'tags': [
+      {
+       'name': 'HTTP Methods',
+       'description': 'Testing different HTTP verbs',
+       # 'externalDocs': {'description': 'Learn more', 'url': 'https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html'}
+      },
+      {'name': 'Auth', 'description': 'Auth methods'},
+      {'name': 'Status codes', 'description': 'Generates responses with given status code'},
+      {'name': 'Request inspection', 'description': 'Inspect the request data'},
+      {'name': 'Response inspection', 'description': 'Inspect the response data like caching and headers'},
+      {'name': 'Response formats', 'description': 'Returns responses in different data formats'},
+      {'name': 'Dynamic data', 'description': 'Generates random and dynamic data'},
+      {'name': 'Cookies', 'description': 'Creates, reads and deletes Cookies'},
+      {'name': 'Images', 'description': 'Returns different image formats'},
+      {'name': 'Redirects', 'description': 'Returns different redirect responses'},
+      {'name': 'Anything', 'description': 'Returns anything that is passed to request'},
   ]
 }
 
@@ -170,17 +188,18 @@ def set_cors_headers(response):
 # Routes
 # ------
 
-# @app.route('/')
-# def view_landing_page():
-#     """Generates Landing Page."""
-#     tracking_enabled = 'HTTPBIN_TRACKING' in os.environ
-#     return render_template('index.html', tracking_enabled=tracking_enabled)
+@app.route('/legacy')
+def view_landing_page():
+    """Generates Landing Page in legacy layout."""
+    return render_template('index.html')
 
 
 @app.route('/html')
 def view_html_page():
     """Returns a simple HTML document.
     ---
+    tags:
+      - Response formats
     responses:
       200:
         description: An HTML page.
@@ -191,7 +210,14 @@ def view_html_page():
 
 @app.route('/robots.txt')
 def view_robots_page():
-    """Returns a simple HTML document."""
+    """Returns some robots.txt rules.
+    ---
+    tags:
+      - Response formats
+    responses:
+      200:
+        description: Robots file
+    """
 
     response = make_response()
     response.data = ROBOT_TXT
@@ -201,7 +227,14 @@ def view_robots_page():
 
 @app.route('/deny')
 def view_deny_page():
-    """Simple Html Page"""
+    """Returns page denied by robots.txt rules.
+    ---
+    tags:
+      - Response formats
+    responses:
+      200:
+        description: Denied message
+    """
     response = make_response()
     response.data = ANGRY_ASCII
     response.content_type = "text/plain"
@@ -213,6 +246,8 @@ def view_deny_page():
 def view_origin():
     """Returns the requester's IP Address.
     ---
+    tags:
+      - Request inspection
     responses:
       200:
         description: The Requester's IP Address.
@@ -225,6 +260,8 @@ def view_origin():
 def view_uuid():
     """Return a UUID4.
     ---
+    tags:
+      - Dynamic data
     responses:
       200:
         description: A UUID4.
@@ -237,6 +274,8 @@ def view_uuid():
 def view_headers():
     """Return the incoming requests's HTTP headers.
     ---
+    tags:
+      - Request inspection
     responses:
       200:
         description: The Rrquest's IP Address.
@@ -249,6 +288,8 @@ def view_headers():
 def view_user_agent():
     """Return the incoming requests's User-Agent header.
     ---
+    tags:
+      - Request inspection
     responses:
       200:
         description: The request's User-Agent header..
@@ -263,6 +304,8 @@ def view_user_agent():
 def view_get():
     """The request's query parameters.
     ---
+    tags:
+      - HTTP Methods
     responses:
       200:
         description: The request's query parameters.
@@ -274,7 +317,14 @@ def view_get():
 @app.route('/anything', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'TRACE'])
 @app.route('/anything/<path:anything>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'TRACE'])
 def view_anything(anything=None):
-    """Returns request data."""
+    """Returns anything passed in request data.
+    ---
+    tags:
+      - Anything
+    responses:
+      200:
+        description: Anything passed in request
+    """
 
     return jsonify(get_dict('url', 'args', 'headers', 'origin', 'method', 'form', 'data', 'files', 'json'))
 
@@ -283,6 +333,8 @@ def view_anything(anything=None):
 def view_post():
     """The request's POST parameters.
     ---
+    tags:
+      - HTTP Methods
     responses:
       200:
         description: The request's POST parameters.
@@ -296,6 +348,8 @@ def view_post():
 def view_put():
     """The request's PUT parameters.
     ---
+    tags:
+      - HTTP Methods
     responses:
       200:
         description: The request's PUT parameters.
@@ -309,6 +363,8 @@ def view_put():
 def view_patch():
     """The request's PATCH parameters.
     ---
+    tags:
+      - HTTP Methods
     responses:
       200:
         description: The request's PATCH parameters.
@@ -322,6 +378,8 @@ def view_patch():
 def view_delete():
     """"The request's DELETE parameters.
     ---
+    tags:
+      - HTTP Methods
     responses:
       200:
         description: The request's DELETE parameters.
@@ -336,6 +394,8 @@ def view_delete():
 def view_gzip_encoded_content():
     """Returns GZip-encoded data.
     ---
+    tags:
+      - Response formats
     responses:
       200:
         description: GZip-encoded data.
@@ -350,6 +410,8 @@ def view_gzip_encoded_content():
 def view_deflate_encoded_content():
     """"Returns Deflate-encoded data.
     ---
+    tags:
+      - Response formats
     responses:
       200:
         description: Defalte-encoded data.
@@ -364,6 +426,8 @@ def view_deflate_encoded_content():
 def view_brotli_encoded_content():
     """"Returns Brotli-encoded data.
     ---
+    tags:
+      - Response formats
     responses:
       200:
         description: Brotli-encoded data.
@@ -377,6 +441,8 @@ def view_brotli_encoded_content():
 def redirect_n_times(n):
     """302 Redirects n times.
     ---
+    tags:
+      - Redirects
     parameters:
       - in: path
         name: n
@@ -406,6 +472,8 @@ def _redirect(kind, n, external):
 def redirect_to():
     """302/3XX Redirects to the given URL.
     ---
+    tags:
+      - Redirects
     parameters:
       - name: url
         type: string
@@ -436,6 +504,8 @@ def redirect_to():
 def relative_redirect_n_times(n):
     """Relatively 302 Redirects n times.
     ---
+    tags:
+      - Redirects
     parameters:
       - in: path
         name: n
@@ -462,6 +532,8 @@ def relative_redirect_n_times(n):
 def absolute_redirect_n_times(n):
     """Absolutely 302 Redirects n times.
     ---
+    tags:
+      - Redirects
     parameters:
       - in: path
         name: n
@@ -483,6 +555,8 @@ def absolute_redirect_n_times(n):
 def stream_n_messages(n):
     """Stream n JSON responses
     ---
+    tags:
+      - Dynamic data
     parameters:
       - in: path
         name: n
@@ -506,7 +580,25 @@ def stream_n_messages(n):
 
 @app.route('/status/<codes>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'TRACE'])
 def view_status_code(codes):
-    """Return status code or random status code if more than one are given"""
+    """Return status code or random status code if more than one are given
+    ---
+    tags:
+      - Status codes
+    parameters:
+      - in: path
+        name: codes
+    responses:
+      100:
+        description: Informational responses
+      200:
+        description: Success
+      300:
+        description: Redirection
+      400:
+        description: Client Errors
+      500:
+        description: Server Errors
+    """
 
     if ',' not in codes:
         try:
@@ -535,7 +627,26 @@ def view_status_code(codes):
 
 @app.route('/response-headers', methods=['GET', 'POST'])
 def response_headers():
-    """Returns a set of response headers from the query string."""
+    """Returns a set of response headers from the query string.
+    ---
+    tags:
+      - Response inspection
+    parameters:
+      - in: query
+        name: freeform
+        explode: true
+        allowEmptyValue: true
+        schema:
+          type: object
+          additionalProperties:
+            type: string
+        style: form
+    responses:
+      200:
+        description: Response headers
+    """
+    # Pending swaggerUI update
+    # https://github.com/swagger-api/swagger-ui/issues/3850
     headers = MultiDict(request.args.items(multi=True))
     response = jsonify(list(headers.lists()))
 
@@ -560,6 +671,8 @@ def response_headers():
 def view_cookies(hide_env=True):
     """Returns cookie data.
     ---
+    tags:
+      - Cookies
     responses:
       200:
         description: Set cookies..
@@ -588,6 +701,8 @@ def view_forms_post():
 def set_cookie(name, value):
     """Sets a cookie and redirects to cookie list.
     ---
+    tags:
+      - Cookies
     parameters:
       - in: path
         name: name
@@ -597,7 +712,7 @@ def set_cookie(name, value):
         type: string
     responses:
       200:
-        description: Set cookies.
+        description: Set cookies and redirects to cookie list.
     """
 
     r = app.make_response(redirect(url_for('view_cookies')))
@@ -608,7 +723,24 @@ def set_cookie(name, value):
 
 @app.route('/cookies/set')
 def set_cookies():
-    """Sets cookie(s) as provided by the query string and redirects to cookie list."""
+    """Sets cookie(s) as provided by the query string and redirects to cookie list.
+    ---
+    tags:
+      - Cookies
+    parameters:
+      - in: query
+        name: freeform
+        explode: true
+        allowEmptyValue: true
+        schema:
+          type: object
+          additionalProperties:
+            type: string
+        style: form
+    responses:
+      200:
+        description: Redirect to cookie list
+    """
 
     cookies = dict(request.args.items())
     r = app.make_response(redirect(url_for('view_cookies')))
@@ -620,7 +752,24 @@ def set_cookies():
 
 @app.route('/cookies/delete')
 def delete_cookies():
-    """Deletes cookie(s) as provided by the query string and redirects to cookie list."""
+    """Deletes cookie(s) as provided by the query string and redirects to cookie list.
+    ---
+    tags:
+      - Cookies
+    parameters:
+      - in: query
+        name: freeform
+        explode: true
+        allowEmptyValue: true
+        schema:
+          type: object
+          additionalProperties:
+            type: string
+        style: form
+    responses:
+      200:
+        description: Redirect to cookie list
+    """
 
     cookies = dict(request.args.items())
     r = app.make_response(redirect(url_for('view_cookies')))
@@ -634,6 +783,8 @@ def delete_cookies():
 def basic_auth(user='user', passwd='passwd'):
     """Prompts the user for authorization using HTTP Basic Auth.
     ---
+    tags:
+      - Auth
     parameters:
       - in: path
         name: user
@@ -658,6 +809,8 @@ def basic_auth(user='user', passwd='passwd'):
 def hidden_basic_auth(user='user', passwd='passwd'):
     """"Prompts the user for authorization using HTTP Basic Auth.
     ---
+    tags:
+      - Auth
     parameters:
       - in: path
         name: user
@@ -681,6 +834,8 @@ def hidden_basic_auth(user='user', passwd='passwd'):
 def bearer_auth():
     """"Prompts the user for authorization using bearer authentication..
     ---
+    tags:
+      - Auth
     responses:
       200:
         description: Sucessful authentication.
@@ -702,10 +857,13 @@ def bearer_auth():
 def digest_auth_md5(qop=None, user='user', passwd='passwd'):
     """"Prompts the user for authorization using Digest Auth.
     ---
+    tags:
+      - Auth
     parameters:
       - in: path
         name: qop
         type: string
+        description: auth or auth-int
       - in: path
         name: user
         type: string
@@ -723,12 +881,68 @@ def digest_auth_md5(qop=None, user='user', passwd='passwd'):
 
 @app.route('/digest-auth/<qop>/<user>/<passwd>/<algorithm>')
 def digest_auth_nostale(qop=None, user='user', passwd='passwd', algorithm='MD5'):
+    """"Prompts the user for authorization using Digest Auth + Algorithm.
+    ---
+    tags:
+      - Auth
+    parameters:
+      - in: path
+        name: qop
+        type: string
+        description: auth or auth-int
+      - in: path
+        name: user
+        type: string
+      - in: path
+        name: passwd
+        type: string
+      - in: path
+        name: algorithm
+        type: string
+        description: MD5, SHA-256, SHA-512
+        default: MD5
+    responses:
+      200:
+        description: Sucessful authentication.
+      401:
+        description: Unsuccessful authentication.
+    """
     return digest_auth(qop, user, passwd, algorithm, 'never')
 
 
 @app.route('/digest-auth/<qop>/<user>/<passwd>/<algorithm>/<stale_after>')
 def digest_auth(qop=None, user='user', passwd='passwd', algorithm='MD5', stale_after='never'):
-    """Prompts the user for authorization using HTTP Digest auth"""
+    """"Prompts the user for authorization using Digest Auth + Algorithm.
+    allow settings the stale_after argument.
+    ---
+    tags:
+      - Auth
+    parameters:
+      - in: path
+        name: qop
+        type: string
+        description: auth or auth-int
+      - in: path
+        name: user
+        type: string
+      - in: path
+        name: passwd
+        type: string
+      - in: path
+        name: algorithm
+        type: string
+        description: MD5, SHA-256, SHA-512
+        default: MD5
+      - in: path
+        name: stale_after
+        type: string
+        default: never
+    responses:
+      200:
+        description: Sucessful authentication.
+      401:
+        description: Unsuccessful authentication.
+    """
     require_cookie_handling = (request.args.get('require-cookie', '').lower() in
                                ('1', 't', 'true'))
     if algorithm not in ('MD5', 'SHA-256', 'SHA-512'):
@@ -791,6 +1005,8 @@ def digest_auth(qop=None, user='user', passwd='passwd', algorithm='MD5', stale_a
 def delay_response(delay):
     """"Returns a delayed response (max of 10 seconds).
     ---
+    tags:
+      - Dynamic data
     parameters:
       - in: path
         name: delay
@@ -811,6 +1027,8 @@ def delay_response(delay):
 def drip():
     """Drips data over a duration after an optional initial delay.
     ---
+    tags:
+      - Dynamic data
     responses:
       200:
         description: A dripped response.
@@ -847,6 +1065,8 @@ def drip():
 def decode_base64(value):
     """"RDecodes base64url-encoded string.
     ---
+    tags:
+      - Dynamic data
     parameters:
       - in: path
         name: value
@@ -861,7 +1081,22 @@ def decode_base64(value):
 
 @app.route('/cache', methods=('GET',))
 def cache():
-    """Returns a 304 if an If-Modified-Since header or If-None-Match is present. Returns the same as a GET otherwise."""
+    """Returns a 304 if an If-Modified-Since header or If-None-Match is present. Returns the same as a GET otherwise.
+    ---
+    tags:
+      - Response inspection
+    parameters:
+      - in: header
+        name: If-Modified-Since
+      - in: header
+        name: If-None-Match
+    responses:
+      200:
+        description: Cached response
+      304:
+        description: Modified
+
+    """
     is_conditional = request.headers.get('If-Modified-Since') or request.headers.get('If-None-Match')
 
     if is_conditional is None:
@@ -874,7 +1109,22 @@ def cache():
 
 @app.route('/etag/<etag>', methods=('GET',))
 def etag(etag):
-    """Assumes the resource has the given etag and responds to If-None-Match and If-Match headers appropriately."""
+    """Assumes the resource has the given etag and responds to If-None-Match and If-Match headers appropriately.
+    ---
+    tags:
+      - Response inspection
+    parameters:
+      - in: header
+        name: If-None-Match
+      - in: header
+        name: If-Match
+    responses:
+      200:
+        description: Normal response
+      412:
+        description: match
+
+    """
     if_none_match = parse_multi_value_header(request.headers.get('If-None-Match'))
     if_match = parse_multi_value_header(request.headers.get('If-Match'))
 
@@ -894,7 +1144,18 @@ def etag(etag):
 
 @app.route('/cache/<int:value>')
 def cache_control(value):
-    """Sets a Cache-Control header."""
+    """Sets a Cache-Control header for n seconds.
+    ---
+    tags:
+      - Response inspection
+    parameters:
+      - in: path
+        name: value
+        type: integer
+    responses:
+      200:
+        description: Cache control set
+    """
     response = view_get()
     response.headers['Cache-Control'] = 'public, max-age={0}'.format(value)
     return response
@@ -903,7 +1164,9 @@ def cache_control(value):
 @app.route('/encoding/utf8')
 def encoding():
     """Returns a UTF-8 encoded body.
-     ---
+    ---
+    tags:
+      - Response formats
     responses:
       200:
         description: Encoded UTF-8 content.
@@ -914,8 +1177,10 @@ def encoding():
 
 @app.route('/bytes/<int:n>')
 def random_bytes(n):
-    """Returns n random bytes generated with given seed.
-     ---
+    """Returns n random bytes generated with given seed
+    ---
+    tags:
+      - Dynamic data
     parameters:
       - in: path
         name: n
@@ -925,7 +1190,7 @@ def random_bytes(n):
         description: Bytes.
     """
 
-    n = min(n, 100 * 1024) # set 100KB limit
+    n = min(n, 100 * 1024)  # set 100KB limit
 
     params = CaseInsensitiveDict(request.args.items())
     if 'seed' in params:
@@ -942,7 +1207,9 @@ def random_bytes(n):
 @app.route('/stream-bytes/<int:n>')
 def stream_random_bytes(n):
     """Streams n random bytes generated with given seed, at given chunk size per packet.
-     ---
+    ---
+    tags:
+      - Dynamic data
     parameters:
       - in: path
         name: n
@@ -981,7 +1248,9 @@ def stream_random_bytes(n):
 @app.route('/range/<int:numbytes>')
 def range_request(numbytes):
     """Streams n random bytes generated with given seed, at given chunk size per packet.
-     ---
+    ---
+    tags:
+      - Dynamic data
     parameters:
       - in: path
         name: numbytes
@@ -1061,7 +1330,9 @@ def range_request(numbytes):
 @app.route('/links/<int:n>/<int:offset>')
 def link_page(n, offset):
     """Generate a page containing n links to other pages which do the same.
-     ---
+    ---
+    tags:
+      - Dynamic data
     parameters:
       - in: path
         name: n
@@ -1098,6 +1369,8 @@ def links(n):
 def image():
     """Returns a simple image of the type suggest by the Accept header.
     ---
+    tags:
+      - Images
     responses:
       200:
         description: An image.
@@ -1125,6 +1398,8 @@ def image():
 def image_png():
     """Returns a simple PNG image.
     ---
+    tags:
+      - Images
     responses:
       200:
         description: A PNG image.
@@ -1137,6 +1412,8 @@ def image_png():
 def image_jpeg():
     """Returns a simple JPEG image.
     ---
+    tags:
+      - Images
     responses:
       200:
         description: A JPEG image.
@@ -1149,6 +1426,8 @@ def image_jpeg():
 def image_webp():
     """Returns a simple WEBP image.
     ---
+    tags:
+      - Images
     responses:
       200:
         description: A WEBP image.
@@ -1161,6 +1440,8 @@ def image_webp():
 def image_svg():
     """Returns a simple SVG image.
     ---
+    tags:
+      - Images
     responses:
       200:
         description: An SVG image.
@@ -1180,6 +1461,8 @@ def resource(filename):
 def xml():
     """Returns a simple XML document.
     ---
+    tags:
+      - Response formats
     responses:
       200:
         description: An XML document.

--- a/httpbin/templates/flasgger/index.html
+++ b/httpbin/templates/flasgger/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title }}</title>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="{{url_for('flasgger.static', filename='swagger-ui.css')}}" >
+  <link rel="icon" type="image/png" href="{{url_for('flasgger.static', filename='favicon-32x32.png')}}" sizes="32x32" />
+  <link rel="icon" type="image/png" href="{{url_for('flasgger.static', filename='favicon-16x16.png')}}" sizes="16x16" />
+  <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
+</head>
+
+<body>
+    <a href="http://github.com/kennethreitz/httpbin"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
+  <defs>
+    <symbol viewBox="0 0 20 20" id="unlocked">
+          <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="locked">
+      <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8zM12 8H8V5.199C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="close">
+      <path d="M14.348 14.849c-.469.469-1.229.469-1.697 0L10 11.819l-2.651 3.029c-.469.469-1.229.469-1.697 0-.469-.469-.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-.469-.469-.469-1.228 0-1.697.469-.469 1.228-.469 1.697 0L10 8.183l2.651-3.031c.469-.469 1.228-.469 1.697 0 .469.469.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c.469.469.469 1.229 0 1.698z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="large-arrow">
+      <path d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="large-arrow-down">
+      <path d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z"/>
+    </symbol>
+
+
+    <symbol viewBox="0 0 24 24" id="jump-to">
+      <path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.41L5.83 13H21V7z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 24 24" id="expand">
+      <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
+    </symbol>
+
+  </defs>
+</svg>
+
+<div id="swagger-ui"></div>
+
+
+<div class='swagger-ui'>
+<div class="wrapper">
+    <section class="clear">
+        <span style="float: right;">
+            [Powered by <a target="_blank" href="https://github.com/rochacbruno/flasgger">Flasgger</a>]
+            <br>
+        </span>
+    </section>
+</div>
+</div>
+
+
+
+<script src="{{url_for('flasgger.static', filename='swagger-ui-bundle.js')}}"> </script>
+<script src="{{url_for('flasgger.static', filename='swagger-ui-standalone-preset.js')}}"> </script>
+<script src='{{url_for('flasgger.static', filename='')}}lib/jquery.min.js' type='text/javascript'></script>
+<script>
+
+window.onload = function() {
+    {% if config.JWT_AUTH_URL_RULE -%}
+    // JWT token holder
+    var jwt_token;
+    {%- endif %}
+
+    fetch("{{ specs[0]['url'] }}")
+    .then(function(response) {
+        response.json()
+        .then(function(json) {
+        var current_protocol = window.location.protocol.slice(0, -1);
+        if (json.schemes[0] != current_protocol){
+            // Switches scheme to the current in use
+            var other_protocol = json.schemes[0];
+            json.schemes[0] = current_protocol;
+            json.schemes[1] = other_protocol;
+
+        }
+        json.host = window.location.host;  // sets the current host
+    
+        const ui = SwaggerUIBundle({
+            spec: json,
+            validatorUrl: null,
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            jsonEditor: true,
+            docExpansion: "none",
+            apisSorter: "alpha",
+            //operationsSorter: "alpha",
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                // yay ES6 modules ↘
+                Array.isArray(SwaggerUIStandalonePreset) ? SwaggerUIStandalonePreset : SwaggerUIStandalonePreset.default
+            ],
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+            {% if config.JWT_AUTH_URL_RULE -%}
+            requestInterceptor: function(request) {
+            if (jwt_token) {
+                request.headers.Authorization = "Bearer " + jwt_token;
+            }
+
+            return request;
+            },
+            responseInterceptor: function(response) {
+            var tokenField = 'jwt-token';
+            var headers = response.headers;
+
+            if (headers.hasOwnProperty(tokenField)) {
+                jwt_token = headers[tokenField];
+            }
+
+            return response;
+            },
+            {%- endif %}
+            // layout: "StandaloneLayout"  // uncomment to enable the green top header
+        })
+    
+        window.ui = ui
+
+        // uncomment to rename the top brand if layout is enabled
+        // $(".topbar-wrapper .link span").replaceWith("<span>httpbin</span>");
+        })
+    })
+}
+</script>
+
+{% if tracking_enabled %}
+    {% include 'trackingscripts.html' %}
+{% endif %}
+
+{% include 'footer.html' %}
+</body> 
+</html>

--- a/httpbin/templates/footer.html
+++ b/httpbin/templates/footer.html
@@ -1,0 +1,46 @@
+<div class='swagger-ui'>
+<div class="wrapper">
+<section class="block col-12 block-desktop col-12-desktop">
+<div>
+       
+<h2>Utilities</h2>
+
+<ul>
+    <li><a href="{{url_for('view_forms_post')}}">HTML form</a> that posts to /post /forms/post</li>
+    <li><a href='//now.httpbin.org'>now.httpbin.org</a> The current time, in a variety of formats."</li>
+</ul>
+
+    
+<p>Freely hosted in <a href="http://httpbin.org">HTTP</a>, <a href="https://httpbin.org">HTTPS</a>, &amp; <a href="http://eu.httpbin.org/">EU</a> flavors by <a href="http://kennethreitz.org/bitcoin">Kenneth Reitz</a> &amp; <a href="https://www.heroku.com/python">Heroku</a>.</p>
+
+<h2 id="Installing-and-running-from-PyPI">Installing and running from PyPI</h2>
+
+<p>You can install httpbin as a library from PyPI and run it as a WSGI app.  For example, using Gunicorn:</p>
+
+<pre><code class="bash">$ pip install httpbin
+$ gunicorn httpbin:app
+</code></pre>
+
+<h2>Running with docker</h2>
+<code>$ docker run -p 80:80 kennethreitz/httpbin</code>
+
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>A <a href="http://kennethreitz.com/">Kenneth Reitz</a> project.</p>
+<p>BTC: <a href="https://www.kennethreitz.org/bitcoin"><code>1Me2iXTJ91FYZhrGvaGaRDCBtnZ4KdxCug</code></a></p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p><a href="https://www.hurl.it">Hurl.it</a> - Make HTTP requests.</p>
+<p><a href="http://requestb.in">RequestBin</a> - Inspect HTTP requests.</p>
+<p><a href="http://python-requests.org" data-bare-link="true">http://python-requests.org</a></p>
+
+
+<h2>Legacy httpbin website</h2>
+To access the old layout <a href='{{url_for("view_landing_page")}}'>click here</a>
+<br /><br />
+</div>
+</section>
+</div>
+</div>


### PR DESCRIPTION
- Categorized endpoints (by tags)
- Adjusted missing  endpoints
- Added /legacy as a path to old style website
- Scheme will default to `window.location.protocol` so if user access in https it will work
- Customized the `flasgger/index.html` template (removed topbar)
- added footer for info
- added `fork me on github` badge

Pictures

## Categories collapsed by default
> removed the green top header to be a minimalist and clean website
![httpbin1](https://user-images.githubusercontent.com/458654/40250423-9d403812-5aac-11e8-8b6c-482d62a70c49.png)


## Added footer (migrated from old layout)
![httpbin2](https://user-images.githubusercontent.com/458654/40250422-9d21f8ac-5aac-11e8-962f-edbc348cf2a0.png)


## Expanded
![httpbin3](https://user-images.githubusercontent.com/458654/40250421-9cecd082-5aac-11e8-86c3-1f52d066d186.png)
