### PR TITLE
Fix #454: Support `show_env` param in `/headers`

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -282,7 +282,7 @@ def view_uuid():
 
 @app.route('/headers')
 def view_headers():
-    """Return the incoming requests's HTTP headers.
+    """Return the incoming request's HTTP headers.
     ---
     tags:
       - Request inspection
@@ -290,10 +290,10 @@ def view_headers():
       - application/json
     responses:
       200:
-        description: The Rrquest's IP Address.
+        description: The request's headers.
     """
 
-    return jsonify(get_dict('headers'))
+    return jsonify(get_headers())
 
 
 @app.route('/user-agent')

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -265,6 +265,30 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(
             response.headers.get('Access-Control-Allow-Headers'), 'X-Test-Header'
         )
+
+    def test_headers(self):
+        headers = {
+            "Accept": "*/*",
+            "Host": "localhost:1234",
+            "User-Agent": "curl/7.54.0",
+            "Via": "bar"
+        }
+        response = self.app.get('/headers', headers=headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue({'Accept', 'Host', 'User-Agent'}.issubset(set(response.json.keys())))
+        self.assertNotIn('Via', response.json)
+
+    def test_headers_show_env(self):
+        headers = {
+            "Accept": "*/*",
+            "Host": "localhost:1234",
+            "User-Agent": "curl/7.54.0",
+            "Via": "bar"
+        }
+        response = self.app.get('/headers?show_env=true', headers=headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue({'Accept', 'Host', 'User-Agent', 'Via'}.issubset(set(response.json.keys())))
+
     def test_user_agent(self):
         response = self.app.get(
             '/user-agent', headers={'User-Agent': 'test'}


### PR DESCRIPTION
If `show_env` is True, then return all the headers without stripping `ENV_HEADERS`. Also adds tests for `/headers` endpoint.

Signed-off-by: Sanket Saurav <sanketsaurav@gmail.com>