### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:18.04
 
-ADD . /httpbin
-
 RUN apt update -y
 RUN apt install python3-pip -y
+
+ADD . /httpbin
+
 RUN pip3 install --no-cache-dir gunicorn /httpbin
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM ubuntu:18.04
 
-RUN apt update -y
-RUN apt install python3-pip -y
+RUN apt update -y && apt install python3-pip -y
+
+EXPOSE 80
 
 ADD . /httpbin
 
 RUN pip3 install --no-cache-dir gunicorn /httpbin
-
-EXPOSE 80
 
 CMD ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]


### PR DESCRIPTION
### Before the fix
Changing any file lead to repeatedly creating new layers for `RUN apt update -y ` and `apt install python3-pip -y` which is slow and takes up much space

### After the fix
Apply best practices from https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run and https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#build-cache

 `RUN apt update -y ` and `apt install python3-pip -y` is cached. The `docker build` becomes faster, fewer layers are created. Users of the Dockerfile and `docker-compose` need to download less from Dockerhub if anything in this project is changed