### PR TITLE
Manifest fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README.rst LICENSE AUTHORS requirements.txt test_httpbin.py
+include README.rst LICENSE AUTHORS test_httpbin.py
 recursive-include httpbin/templates *
 recursive-include httpbin/static *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README.rst LICENSE AUTHORS test_httpbin.py
+include README.md LICENSE AUTHORS test_httpbin.py
 recursive-include httpbin/templates *
 recursive-include httpbin/static *


### PR DESCRIPTION
Removed `requirements.txt` which was removed when the migration to `pipenv`/`Pipfile` occurred.
Fixed `README.md` mention - notably this file has toggled more than once between `README.rst` and `README.md` but I assume it is stable now.