### PR TITLE
Fix incorrect /bearer behavior

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -913,7 +913,8 @@ def bearer_auth():
         response.headers['WWW-Authenticate'] = 'Bearer'
         response.status_code = 401
         return response
-    token = authorization.split('Bearer ', 1).pop()
+    slice_start = len('Bearer ')
+    token = authorization[slice_start:]
 
     return jsonify(authenticated=True, token=token)
 

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -907,13 +907,13 @@ def bearer_auth():
       401:
         description: Unsuccessful authentication.
     """
-    if 'Authorization' not in request.headers:
+    authorization = request.headers.get('Authorization')
+    if not (authorization and authorization.startswith('Bearer ')):
         response = app.make_response('')
         response.headers['WWW-Authenticate'] = 'Bearer'
         response.status_code = 401
         return response
-    authorization = request.headers.get('Authorization')
-    token = authorization.lstrip('Bearer ')
+    token = authorization.split('Bearer ', 1).pop()
 
     return jsonify(authenticated=True, token=token)
 


### PR DESCRIPTION
There are currently two issues with `/bearer`:

1. It accepts any `Authorization` header, e.g.

   ```
   Authorization: Basic ...
   Authorization: 123abc
   ```

   rather than just `Authorization: Bearer ...` as defined by [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1).

2) If the bearer token starts with a combination of characters `aBer`, the returned `token` has these characters removed. This is caused by using [`lstrip`](https://docs.python.org/3/library/stdtypes.html#str.lstrip):

   ```
   token = authorization.lstrip('Bearer ')
   ```

   The issue happens because the argument of `lstrip` is not a prefix, but a set of characters to be removed.


This PR fixes both issues and adds the corresponding tests.