### PR TITLE
Pretty-print JSON responses

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -55,6 +55,7 @@ tmpl_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
 
 app = Flask(__name__, template_folder=tmpl_dir)
 app.debug = bool(os.environ.get('DEBUG'))
+app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
 
 app.add_template_global('HTTPBIN_TRACKING' in os.environ, name='tracking_enabled')
 


### PR DESCRIPTION
Previously httpbin used to return pretty-printed JSON, which was easy to read when viewing raw responses. But now the responses are minified.

httpbin uses Flask, and Flask 1.0 [changed the default](http://flask.pocoo.org/docs/1.0/changelog/#version-1-0) for [`JSONIFY_PRETTYPRINT_REGULAR`](http://flask.pocoo.org/docs/1.0/config/#JSONIFY_PRETTYPRINT_REGULAR) to `False`, which is what probably caused the change in httpbin's behavior.

This PR explicitly sets [`JSONIFY_PRETTYPRINT_REGULAR`](http://flask.pocoo.org/docs/1.0/config/#JSONIFY_PRETTYPRINT_REGULAR) to `True` to pretty-print JSON responses.