### PR TITLE
Support more HTTP methods for /delay

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -1072,7 +1072,7 @@ def digest_auth(qop=None, user='user', passwd='passwd', algorithm='MD5', stale_a
     return response
 
 
-@app.route('/delay/<delay>')
+@app.route('/delay/<delay>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'TRACE'])
 def delay_response(delay):
     """"Returns a delayed response (max of 10 seconds).
     ---


### PR DESCRIPTION
We have code that only does POST requests so the method is fixed to be POST. Still, we'd like to test that code so we need `/delay` to work with POST as well.

Since I was already at it I've added other methods often used with other endpoints as well.

This fixes issues like #338.