### PR TITLE
Added a .dockerignore file to ignore Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile


### PR DESCRIPTION
Adds a `.dockerignore` file to instruct Docker to exclude `Dockerfile` from the build-context.  This has two effects:

1. Stops `Dockerfile` from being added to the image under `/httpbin`.  There's no point in it being there, and it might be confusing.
1. More importantly, it improves build caching.  In the current `Dockerfile` the statement `ADD . /httpbin` will add the `Dockerfile` along with everything else, and will cause a cache-miss for this line for edits of `Dockerfile`.  This could be annoying if editing lines after the `ADD` line, as it will cause unnecessary execution of `pip3` etc. for no reason.

This change doesn't do anything to effect normal Docker cache-invalidation when the `Dockerfile` is edited as-normal ... if just prevents changes in the text-file `Dockerfile`, needlessly added to the container, from invalidating the cache on file-adds.

## Build testing

1. Run a `docker build`
1. Edit `Dockerfile` and add a `RUN echo` just before `CMD`.
1. Run another `docker build` and note that the cache fails early.
1. Add `.dockerignore`.
1. Repeat the above test and note that the cache does not fail early.