### PR TITLE
Added url and status_code as query-string parameters for SwaggerUI

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -511,9 +511,12 @@ def redirect_to():
     produces:
       - text/html
     parameters:
-      - name: url
+      - in: query
+        name: url
         type: string
-      - name: status_code
+        required: true
+      - in: query
+        name: status_code
         type: int
     responses:
       302:

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -510,20 +510,58 @@ def redirect_to():
       - Redirects
     produces:
       - text/html
-    parameters:
-      - in: query
-        name: url
-        type: string
-        required: true
-      - in: query
-        name: status_code
-        type: int
+    get:
+      parameters:
+        - in: query
+          name: url
+          type: string
+          required: true
+        - in: query
+          name: status_code
+          type: int
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      parameters:
+        - in: formData
+          name: url
+          type: string
+          required: true
+        - in: formData
+          name: status_code
+          type: int
+          required: false
+    patch:
+      consumes:
+        - application/x-www-form-urlencoded
+      parameters:
+        - in: formData
+          name: url
+          type: string
+          required: true
+        - in: formData
+          name: status_code
+          type: int
+          required: false
+    put:
+      consumes:
+        - application/x-www-form-urlencoded
+      parameters:
+        - in: formData
+          name: url
+          type: string
+          required: true
+        - in: formData
+          name: status_code
+          type: int
+          required: false
     responses:
       302:
         description: A redirection.
     """
 
-    args = CaseInsensitiveDict(request.args.items())
+    argsDict = request.form.to_dict(flat=True) if request.method in ('POST', 'PATCH', 'PUT') else request.args.items()
+    args = CaseInsensitiveDict(argsDict)
 
     # We need to build the response manually and convert to UTF-8 to prevent
     # werkzeug from "fixing" the URL. This endpoint should set the Location


### PR DESCRIPTION
This fixes the SwaggerUI for `redirect-to` requests, but properly passing `url` and optionally `status_code` as query-strings.

What is not fixed here is ... currently all methods `GET` `POST` go through the same method - both `GET` and `POST` are fixed here, but really `POST` should use `formData` and a body to pass the parameters - it is fixed here but is using queryString same as `GET`.

Fixed #476.