### PR TITLE
Removed hurl.it which is not reachable from references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ See http://httpbin.org for more information.
 ## SEE ALSO
 
 - http://httpbin.org
-- https://www.hurl.it
 - http://requestb.in
 - http://python-requests.org
 - https://grpcb.in/


### PR DESCRIPTION
hurl.it is not reachable as shown below. 

curl -v https://www.hurl.it
* Rebuilt URL to: https://www.hurl.it/
* Hostname was NOT found in DNS cache
*   Trying 184.95.38.200...
* connect to 184.95.38.200 port 443 failed: Connection refused
* Failed to connect to www.hurl.it port 443: Connection refused
* Closing connection 0
curl: (7) Failed to connect to www.hurl.it port 443: Connection refused