### PR TITLE
Revert #457 "Support `show_env` param in `/headers`"

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -342,7 +342,7 @@ def view_headers():
         description: The request's headers.
     """
 
-    return jsonify(get_headers())
+    return jsonify(get_dict('headers'))
 
 
 @app.route("/user-agent")

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -279,7 +279,7 @@ class HttpbinTestCase(unittest.TestCase):
         }
         response = self.app.get('/headers', headers=headers)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue({'Accept', 'Host', 'User-Agent'}.issubset(set(response.json.keys())))
+        self.assertTrue({'Accept', 'Host', 'User-Agent'}.issubset(set(response.json['headers'].keys())))
         self.assertNotIn('Via', response.json)
 
     def test_headers_show_env(self):
@@ -291,7 +291,7 @@ class HttpbinTestCase(unittest.TestCase):
         }
         response = self.app.get('/headers?show_env=true', headers=headers)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue({'Accept', 'Host', 'User-Agent', 'Via'}.issubset(set(response.json.keys())))
+        self.assertTrue({'Accept', 'Host', 'User-Agent', 'Via'}.issubset(set(response.json['headers'].keys())))
 
     def test_user_agent(self):
         response = self.app.get(


### PR DESCRIPTION
Reverts #457. Fixes #487.

The docstring typo fixes are retained, along with the additional tests,
modified to revert to the original `"headers": {` dict format.

The reverted change `get_dict('headers')` -> `get_headers()` was not required. The
query-string `?show_env=1` was already effective in allowing env headers to be
returned.

This partially reverts commit 31ffe79981a079d6605352d2d84de2f2d27ab6db.

That this change was not required (other than the tests, thanks) was hinted-at by @nateprewitt in the review for #457:

> I'm not sure if get_dict change is needed, although it probably won't hurt anything either. I'd definitely like to see the tests merged at the least though.

In fact the `show_env` pass-through option for filtered env headers has been there since that feature was added in bb094d4a .

@sanketsaurav please chime-in here if this analysis seems off.  Your PR might have fixed something for you.  /cc @Fishbowler .