### PR TITLE
Removed (another) stray space from static path for jquery js

### DIFF
--- a/httpbin/templates/flasgger/index.html
+++ b/httpbin/templates/flasgger/index.html
@@ -137,7 +137,7 @@
 
     <script src="{{url_for('flasgger.static', filename='swagger-ui-bundle.js')}}"> </script>
     <script src="{{url_for('flasgger.static', filename='swagger-ui-standalone-preset.js')}}"> </script>
-    <script src='{{url_for('flasgger.static', filename=' ')}}lib/jquery.min.js' type='text/javascript'></script>
+    <script src='{{url_for('flasgger.static', filename='')}}lib/jquery.min.js' type='text/javascript'></script>
     <script>
 
         window.onload = function () {


### PR DESCRIPTION
Fixes:

    GET http://httpbin.org/flasgger_static/%20lib/jquery.min.js 404 (NOT FOUND)
