### PR TITLE
Changes in the local Git db should not invalidate Docker build cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 Dockerfile
+.git


### PR DESCRIPTION
Another small Docker build-cache fix.  Since we `ADD . /httpbin`, this is collecting the local `.git`.  Changes in the state of the local Git repo should not invalidate the Docker build cache.

To test, before/after:
`docker build ...`
then
`docker build ...` (cached)
then
`git commit --allow-empty -m "empty"`
then
`docker build ...`

Currently the last build will cause a cache-miss ... after this change it will not.