### PR TITLE
Dockerfile: Resolve deps using pipenv/Pipefile(.lock)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,18 @@ LABEL version="0.9.2"
 LABEL description="A simple HTTP service."
 LABEL org.kennethreitz.vendor="Kenneth Reitz"
 
-RUN apt update -y && apt install python3-pip -y
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
-EXPOSE 80
+RUN apt update -y && apt install python3-pip git -y && pip3 install --no-cache-dir pipenv
+
+ADD Pipfile Pipfile.lock /httpbin/
+WORKDIR /httpbin
+RUN /bin/bash -c "pip3 install --no-cache-dir -r <(pipenv lock -r)"
 
 ADD . /httpbin
+RUN pip3 install --no-cache-dir /httpbin
 
-RUN pip3 install --no-cache-dir gunicorn /httpbin
+EXPOSE 80
 
 CMD ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]


### PR DESCRIPTION
Been experimenting with `pipenv` for reproducible Docker image builds and came-up with this approach for _httpbin_.

It makes a couple of Docker cacheability improvements - mainly because `Pipfile` and `Pipfile.lock` are added on their own before deps are installed, so changes to the rest of the source-code won't cause a cache-miss and re-download of all the dependencies.

I'm curious as to whether this is an intended use of `pipenv` ... it seems to help solve the problems for installing as _Applications_ (versus _Libraries_) with pinned versions for dependencies for a specific build.

With reference to #493, with this change the built Docker image should contain `greenlet` version `0.14.3` (the locked version), and not the latest `0.14.4` which would be resolved by `setup.py`.

Fixed #493.