### PR TITLE
dynamic url endpoint

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -1796,6 +1796,8 @@ def custom_endpoint(endpoint):
     """
     if endpoint == None:
         conf = request.get_json()
+        if conf == None:
+            return Response(status=400)
         url = conf.get('url', None)
         if url == None:
             return Response(status=400)

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -814,7 +814,7 @@ class HttpbinTestCase(unittest.TestCase):
         response = self.app.put('/once/test')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get('custom'), 'header')
-        self.assertEqual(response.data, '{"test": "response"}')
+        self.assertEqual(response.data, b'{"test": "response"}')
         response = self.app.put('/once/test')
         self.assertEqual(response.status_code, 404)
 
@@ -827,7 +827,7 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.app.get('/once/test')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, '{}')
+        self.assertEqual(response.data, b'{}')
 
     def test_url_is_mandatory_for_custom_url_creation(self):
         response = self.app.post(

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -804,6 +804,41 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get('ETag'), 'abc')
 
+    def test_it_creates_a_custom_url(self):
+        response = self.app.post(
+            '/once',
+            content_type='application/json',
+            data='{"method":"PUT","url":"/test","response":{"test":"response"},"status":200,"headers":{"custom":"header"}}'
+        )
+        self.assertEqual(response.status_code, 200)
+        response = self.app.put('/once/test')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get('custom'), 'header')
+        self.assertEqual(response.data, '{"test": "response"}')
+        response = self.app.put('/once/test')
+        self.assertEqual(response.status_code, 404)
+
+    def test_custom_url_defaults(self):
+        response = self.app.post(
+            '/once',
+            content_type='application/json',
+            data='{"url":"/test"}'
+        )
+        self.assertEqual(response.status_code, 200)
+        response = self.app.get('/once/test')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, '{}')
+
+    def test_url_is_mandatory_for_custom_url_creation(self):
+        response = self.app.post(
+            '/once',
+            content_type='application/json',
+            data='{"method":"PUT","response":{"test":"response"},"status":200,"headers":{"custom":"header"}}'
+        )
+        self.assertEqual(response.status_code, 400)
+        response = self.app.put('/once/test')
+        self.assertEqual(response.status_code, 404)
+
     def test_parse_multi_value_header(self):
         self.assertEqual(parse_multi_value_header('xyzzy'), [ "xyzzy" ])
         self.assertEqual(parse_multi_value_header('"xyzzy"'), [ "xyzzy" ])

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -829,6 +829,12 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, b'{}')
 
+    def test_json_body_is_mandatory_for_custom_url_creation(self):
+        response = self.app.post(
+            '/once'
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_url_is_mandatory_for_custom_url_creation(self):
         response = self.app.post(
             '/once',


### PR DESCRIPTION
Hello all.
I've added the new `/once` enpoint that dynamically creates a custom endpoint that lives only for one request.
This can be useful when you have to simulate a specific API.

I hope you enjoy this feature.
Bye