### PR TITLE
Dockerized tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
-Dockerfile
-.git
+**
+
+!/httpbin
+!/requirements.txt
+!/test_httpbin.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
-FROM ubuntu:18.04
+FROM python:3-alpine
 
 LABEL name="httpbin"
 LABEL version="0.9.2"
 LABEL description="A simple HTTP service."
 LABEL org.kennethreitz.vendor="Kenneth Reitz"
 
-RUN apt update -y && apt install python3-pip -y
+WORKDIR /srv
+
+# until we have precompiled gevent + brotli, we need this:
+RUN apk add --no-cache --repository=http://nl.alpinelinux.org/alpine/v3.8/main \
+    build-base \
+    gcc \
+    musl-dev
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
 
 EXPOSE 80
-
-ADD . /httpbin
-
-RUN pip3 install --no-cache-dir gunicorn /httpbin
 
 CMD ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,15 @@
 version: '2'
 services:
+
+    # run local httpbin server
     httpbin:
-      build: '.'
+      build: .
+      image: httpbin:latest
       ports:
         - '80:80'
+
+    # run tox-like tests (for python3 only)
+    unittest:
+      # reuse already built image
+      image: httpbin:latest
+      command: ./test_httpbin.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+brotli==1.0.6
+decorator==4.3.0
+flasgger==0.9.1
+Flask==1.0.2
+gevent==1.3.7
+gunicorn==19.9.0
+six==1.11.0
+Werkzeug==0.14.1


### PR DESCRIPTION
In this PR:

 * Move docker base image to `python3-alpine` instead of ubuntu.
 * Reduce docker context size with more aggressive `.dockerignore`
 * Add a service that runs `test_httpbin.py` to `docker-compose.yml`

### why
I was not able to run `tox` tests on my mac. I did not dig into that - docker provides more reproducible  environment for running unittests. 