### PR TITLE
Optimize Dockerfile for reducing the size and drop root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
-FROM ubuntu:18.04
+FROM python:3.6.7-slim
 
 LABEL name="httpbin"
 LABEL version="0.9.2"
 LABEL description="A simple HTTP service."
 LABEL org.kennethreitz.vendor="Kenneth Reitz"
 
-RUN apt update -y && apt install python3-pip -y
-
-EXPOSE 80
+EXPOSE 8080
 
 ADD . /httpbin
 
 RUN pip3 install --no-cache-dir gunicorn /httpbin
 
-CMD ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "httpbin:app", "-k", "gevent"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [Kenneth Reitz](http://kennethreitz.org/bitcoin) Project.
 Run locally:
 ```sh
 docker pull kennethreitz/httpbin
-docker run -p 80:80 kennethreitz/httpbin
+docker run -p 8080:8080 kennethreitz/httpbin
 ```
 
 See http://httpbin.org for more information.


### PR DESCRIPTION
- move base from ubuntu to python:3.6.7-slim which decrease the image
  size from 553MB to 192 MB
- Use 8080 for the gunicorn listen port, which could make the image run
  without root priviledge. This is import if you wanna run httpbin in
  OpenShift.