### PR TITLE
Run unittests in docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,16 @@ A [Kenneth Reitz](http://kennethreitz.org/bitcoin) Project.
 
 Run locally:
 ```sh
-docker pull kennethreitz/httpbin
 docker run -p 80:80 kennethreitz/httpbin
+```
+
+Test locally:
+```sh
+# run unittest
+docker-compose up test
+
+# run httpbin server
+docker-compose up httpbin
 ```
 
 See http://httpbin.org for more information.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '2'
+
 services:
     httpbin:
-      build: '.'
+      build: .
+      image: httpbin:latest
       ports:
         - '80:80'
+
+    test:
+      image: httpbin:latest
+      working_dir: /httpbin
+      command: python3 -m unittest --verbose


### PR DESCRIPTION
### why
I was not able to run `tox` tests on mac. I assume this is fixable, but running tests in a container gives a more predictable environment.

### what

 * Added `test` service to `docker-compose.yml` that runs the unittests.
 * Added note in `README.md`
