### PR TITLE
Corrected repository URL in app.json

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Patches and Suggestions
 - Matt Robenolt (https://github.com/mattrobenolt)
 - Dave Challis (https://github.com/davechallis)
 - Florian Bruhin (https://github.com/The-Compiler)
+- Brett Randall (https://github.com/javabrett)

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "httpbin",
   "description": "HTTP Request & Response Service, written in Python + Flask.",
-  "repository": "https://github.com/Runscope/httpbin",
+  "repository": "https://github.com/requests/httpbin",
   "website": "https://httpbin.org",
   "logo": "https://s3.amazonaws.com/f.cl.ly/items/333Y191Z2C0G2J3m3Y0b/httpbin.svg",
   "keywords": ["http", "rest", "API", "testing", "integration", "python", "flask"],


### PR DESCRIPTION
The existing url redirects fine, but we may as well use the direct one.

Also appended to AUTHORS.